### PR TITLE
DEV: removes unnecessary complexity

### DIFF
--- a/assets/javascripts/initializers/shared-edits-init.js.es6
+++ b/assets/javascripts/initializers/shared-edits-init.js.es6
@@ -19,8 +19,8 @@ import { SAVE_LABELS, SAVE_ICONS } from "discourse/models/composer";
 const SHARED_EDIT_ACTION = "sharedEdit";
 
 function initWithApi(api) {
-  SAVE_LABELS[[SHARED_EDIT_ACTION]] = "composer.save_edit";
-  SAVE_ICONS[[SHARED_EDIT_ACTION]] = "pencil-alt";
+  SAVE_LABELS[SHARED_EDIT_ACTION] = "composer.save_edit";
+  SAVE_ICONS[SHARED_EDIT_ACTION] = "pencil-alt";
 
   api.includePostAttributes("shared_edits_enabled");
 
@@ -130,7 +130,7 @@ function initWithApi(api) {
         }
       }
       this._super(...arguments);
-    },
+    }
   });
 
   api.modifyClass("component:composer-editor", {

--- a/assets/javascripts/initializers/shared-edits-init.js.es6
+++ b/assets/javascripts/initializers/shared-edits-init.js.es6
@@ -130,7 +130,7 @@ function initWithApi(api) {
         }
       }
       this._super(...arguments);
-    }
+    },
   });
 
   api.modifyClass("component:composer-editor", {


### PR DESCRIPTION
This wil be implictly converted to a string and doesn't need these double `[[]]`.

```
const EDIT = "edit";
const SAVE_LABELS = { [EDIT]: "composer.save_edit" };

SAVE_LABELS[EDIT] // "composer.save_edit"
```