### PR TITLE
FIX: improve localization and disabled state

### DIFF
--- a/app/controllers/discourse_shared_edits/revision_controller.rb
+++ b/app/controllers/discourse_shared_edits/revision_controller.rb
@@ -3,7 +3,7 @@
 module ::DiscourseSharedEdits
   class RevisionController < ::ApplicationController
     requires_login
-    before_action :ensure_logged_in
+    before_action :ensure_logged_in, :ensure_shared_edits
     skip_before_action :preload_json, :check_xhr
 
     def enable
@@ -84,6 +84,14 @@ module ::DiscourseSharedEdits
         version: version,
         revisions: revisions
       }
+    end
+
+    protected
+
+    def ensure_shared_edits
+      if !SiteSetting.shared_edits_enabled
+        raise Discourse::InvalidAccess
+      end
     end
 
   end

--- a/assets/javascripts/initializers/shared-edits-init.js.es6
+++ b/assets/javascripts/initializers/shared-edits-init.js.es6
@@ -1,12 +1,12 @@
 import { withPluginApi } from "discourse/lib/plugin-api";
 import discourseComputed, {
-  on,
   observes,
+  on,
 } from "discourse-common/utils/decorators";
 import {
+  performSharedEdit,
   setupSharedEdit,
   teardownSharedEdit,
-  performSharedEdit,
 } from "../lib/shared-edits";
 
 import { ajax } from "discourse/lib/ajax";
@@ -14,7 +14,7 @@ import { popupAjaxError } from "discourse/lib/ajax-error";
 
 import { computed } from "@ember/object";
 
-import { SAVE_LABELS, SAVE_ICONS } from "discourse/models/composer";
+import { SAVE_ICONS, SAVE_LABELS } from "discourse/models/composer";
 
 const SHARED_EDIT_ACTION = "sharedEdit";
 
@@ -223,7 +223,12 @@ function initWithApi(api) {
 
 export default {
   name: "discourse-shared-edits",
-  initialize: () => {
+  initialize: (container) => {
+    const siteSettings = container.lookup("site-settings:main");
+    if (!siteSettings.shared_edits_enabled) {
+      return;
+    }
+
     withPluginApi("0.8.6", initWithApi);
   },
 };

--- a/assets/stylesheets/common/discourse-shared-edits.scss
+++ b/assets/stylesheets/common/discourse-shared-edits.scss
@@ -5,7 +5,12 @@
       display: none;
     }
   }
+  .title-and-category,
   .composer-actions {
     display: none;
+  }
+
+  .d-editor-preview-wrapper {
+    margin-top: 0px;
   }
 }

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1,3 +1,5 @@
 en:
   shared_edits:
     reason: "Edited By: %{users}"
+  site_settings:
+    shared_edits_enabled: Enable shared, collaborative, editing on designated posts.

--- a/plugin.rb
+++ b/plugin.rb
@@ -42,7 +42,7 @@ after_initialize do
 
   class ::Guardian
     def can_toggle_shared_edits?
-      is_staff?
+      SiteSetting.shared_edits_enabled && is_staff?
     end
   end
 

--- a/spec/requests/revision_controller_spec.rb
+++ b/spec/requests/revision_controller_spec.rb
@@ -19,6 +19,12 @@ describe ::DiscourseSharedEdits::RevisionController do
       sign_in admin
     end
 
+    it "is hard disabled when plugin is disabled" do
+      SiteSetting.shared_edits_enabled = false
+      put "/shared_edits/p/#{post1.id}/enable"
+      expect(response.status).to eq(403)
+    end
+
     it "is able to enable revisions on a post" do
 
       put "/shared_edits/p/#{post1.id}/enable"


### PR DESCRIPTION
- Add description for site setting
- Properly disable plugin when it is disabled via site settings
- If OP has shared edits suppress title and category (no mechanism for shared edits on title at the moment)
