### PR TITLE
DEV: improve interaction between wiki and shared-edit posts

### DIFF
--- a/assets/javascripts/initializers/shared-edits-init.js.es6
+++ b/assets/javascripts/initializers/shared-edits-init.js.es6
@@ -51,17 +51,11 @@ function initWithApi(api) {
     return attrs.shared_edits_enabled && attrs.canEdit;
   });
 
+  api.removePostMenuButton("wiki-edit", (attrs) => {
+    return attrs.shared_edits_enabled && attrs.canEdit;
+  });
+
   api.reopenWidget("post-menu", {
-    menuItems() {
-      const result = this._super(...arguments);
-
-      if (this.attrs.shared_edits_enabled) {
-        this.attrs.wiki = false;
-      }
-
-      return result;
-    },
-
     sharedEdit() {
       const post = this.findAncestorModel();
       this.appEvents.trigger("shared-edit-on-post", post);

--- a/assets/javascripts/initializers/shared-edits-init.js.es6
+++ b/assets/javascripts/initializers/shared-edits-init.js.es6
@@ -134,6 +134,30 @@ function initWithApi(api) {
     },
   });
 
+  api.modifyClass("controller:history", {
+    pluginId: PLUGIN_ID,
+
+    @discourseComputed("post.shared_edits_enabled")
+    editButtonLabel(sharedEdit) {
+      let label = this._super(...arguments);
+      if (sharedEdit) {
+        label = "post.revisions.controls.edit_post";
+      }
+      return label;
+    },
+
+    actions: {
+      editPost() {
+        if (this.post.shared_edits_enabled) {
+          this.appEvents.trigger("shared-edit-on-post", this.post);
+          this.send("closeModal");
+        } else {
+          this._super(...arguments);
+        }
+      },
+    },
+  });
+
   api.modifyClass("model:composer", {
     pluginId: PLUGIN_ID,
 

--- a/assets/javascripts/initializers/shared-edits-init.js.es6
+++ b/assets/javascripts/initializers/shared-edits-init.js.es6
@@ -47,16 +47,16 @@ function initWithApi(api) {
     return result;
   });
 
+  api.removePostMenuButton("edit", (attrs) => {
+    return attrs.shared_edits_enabled && attrs.canEdit;
+  });
+
   api.reopenWidget("post-menu", {
     menuItems() {
       const result = this._super(...arguments);
 
       if (this.attrs.shared_edits_enabled) {
         this.attrs.wiki = false;
-
-        if (result.includes("edit")) {
-          result.splice(result.indexOf("edit"), 1);
-        }
       }
 
       return result;

--- a/assets/javascripts/initializers/shared-edits-init.js.es6
+++ b/assets/javascripts/initializers/shared-edits-init.js.es6
@@ -16,6 +16,13 @@ import { SAVE_ICONS, SAVE_LABELS } from "discourse/models/composer";
 const SHARED_EDIT_ACTION = "sharedEdit";
 const PLUGIN_ID = "discourse-shared-edits";
 
+function replaceButton(buttons, find, replace) {
+  const idx = buttons.indexOf(find);
+  if (idx !== -1) {
+    buttons[idx] = replace;
+  }
+}
+
 function initWithApi(api) {
   SAVE_LABELS[SHARED_EDIT_ACTION] = "composer.save_edit";
   SAVE_ICONS[SHARED_EDIT_ACTION] = "pencil-alt";
@@ -56,6 +63,22 @@ function initWithApi(api) {
   });
 
   api.reopenWidget("post-menu", {
+    menuItems() {
+      const result = this._super(...arguments);
+
+      // wiki handles the reply button on its own. If not a wiki and is shared-edit
+      // remove the label from the reply button.
+      if (
+        this.attrs.shared_edits_enabled &&
+        this.attrs.canEdit &&
+        !this.attrs.wiki
+      ) {
+        replaceButton(result, "reply", "reply-small");
+      }
+
+      return result;
+    },
+
     sharedEdit() {
       const post = this.findAncestorModel();
       this.appEvents.trigger("shared-edit-on-post", post);

--- a/assets/javascripts/initializers/shared-edits-init.js.es6
+++ b/assets/javascripts/initializers/shared-edits-init.js.es6
@@ -30,8 +30,9 @@ function initWithApi(api) {
   api.includePostAttributes("shared_edits_enabled");
 
   api.addPostClassesCallback((attrs) => {
-    if (attrs.shared_edits_enabled && attrs.canEdit)
+    if (attrs.shared_edits_enabled && attrs.canEdit) {
       return ["shared-edits-post"];
+    }
   });
 
   api.addPostMenuButton("sharedEdit", (post) => {

--- a/assets/javascripts/initializers/shared-edits-init.js.es6
+++ b/assets/javascripts/initializers/shared-edits-init.js.es6
@@ -22,6 +22,11 @@ function initWithApi(api) {
 
   api.includePostAttributes("shared_edits_enabled");
 
+  api.addPostClassesCallback((attrs) => {
+    if (attrs.shared_edits_enabled && attrs.canEdit)
+      return ["shared-edits-post"];
+  });
+
   api.addPostMenuButton("sharedEdit", (post) => {
     if (!post.shared_edits_enabled || !post.canEdit) {
       return;


### PR DESCRIPTION
Context: https://meta.discourse.org/t/discourse-shared-edits/167583/41?u=johani

This PR does six things:

1. Adds a CSS class to `shared-edit` posts for customizability.

2. Improves the way the default edit button is removed. It now uses the `api.removePostMenuButton` plugin API method.

3. Improves the way the `wiki-edit` is removed. It was previously done by setting the post attribute `wiki` to false. This 
caused issues in the post-admin menu, making it always think the post is not a wiki. The toggle worked, but it always showed the label "make-wiki" since it believed that the post was not a wiki.

4. Improves the interaction between shared-edit posts and the revision history modal. The modal shows a button to edit the post (if the user can). That button used to ignore the fact that it can be a shared-edit post causing it to open the default editor instead of the shared-edits composer. This PR fixes that. If the post is a shared-edit, the button will open the shared-edit composer. 

5. If the post is a shared-edit, replace the "reply" button with a "small-reply" button. This prevents a case where we show two buttons with labels next to each other. Core does this already if the post is a wiki, so this PR makes the same change for shared-edit posts.

6. In the revision modal, the edit button label is changed from "edit-post" to "edit-wiki" if the post is a wiki. Currently, setting the post to be a shared-edit + wiki is done to extend the post's edit permission to allow more users to edit the post as a shared edit. This PR overrides that behavior for shared-edit + wiki posts. The button will always show "edit post," just like default. The use case for wiki's here is a workaround and the label change adds more confusion than needed. 