### PR TITLE
DEV: Remove use of run-loop-and-computed-dot-access

### DIFF
--- a/assets/javascripts/initializers/shared-edits-init.js.es6
+++ b/assets/javascripts/initializers/shared-edits-init.js.es6
@@ -10,7 +10,7 @@ import {
 } from "../lib/shared-edits";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
-import { computed } from "@ember/object";
+import { equal } from "@ember/object/computed";
 import { SAVE_ICONS, SAVE_LABELS } from "discourse/models/composer";
 
 const SHARED_EDIT_ACTION = "sharedEdit";
@@ -162,7 +162,7 @@ function initWithApi(api) {
   api.modifyClass("model:composer", {
     pluginId: PLUGIN_ID,
 
-    creatingSharedEdit: computed.equal("action", SHARED_EDIT_ACTION),
+    creatingSharedEdit: equal("action", SHARED_EDIT_ACTION),
 
     @discourseComputed("action")
     editingPost() {


### PR DESCRIPTION
Context: https://deprecations.emberjs.com/v3.x/#toc_deprecated-run-loop-and-computed-dot-access