### PR TITLE
FIX: appEvents.off error when destroying controller:topic

### DIFF
--- a/assets/javascripts/initializers/shared-edits-init.js
+++ b/assets/javascripts/initializers/shared-edits-init.js
@@ -201,21 +201,27 @@ function initWithApi(api) {
     init() {
       this._super(...arguments);
 
-      this.appEvents.on("shared-edit-on-post", (post) => {
-        const draftKey = post.get("topic.draft_key");
-        const draftSequence = post.get("topic.draft_sequence");
+      this.appEvents.on("shared-edit-on-post", this, "_handleSharedEditOnPost");
+    },
 
-        this.get("composer").open({
-          post,
-          action: SHARED_EDIT_ACTION,
-          draftKey,
-          draftSequence,
-        });
+    _handleSharedEditOnPost(post) {
+      const draftKey = post.get("topic.draft_key");
+      const draftSequence = post.get("topic.draft_sequence");
+
+      this.get("composer").open({
+        post,
+        action: SHARED_EDIT_ACTION,
+        draftKey,
+        draftSequence,
       });
     },
 
     willDestroy() {
-      this.appEvents.off("shared-edit-on-post", this);
+      this.appEvents.off(
+        "shared-edit-on-post",
+        this,
+        "_handleSharedEditOnPost"
+      );
       this._super(...arguments);
     },
   });


### PR DESCRIPTION
Fixes an error when the willDestroy function of the topic controller is called, where we weren't using the correct appEvent.off parameters:

> Error: Assertion Failed: You must pass at least an object, event name, and method or target and method/method name to removeListener
> at assert (http://localhost:7357/assets/vendor.js:47587:15)
> at removeListener (http://localhost:7357/assets/vendor.js:23681:184)
> at Class.off (http://localhost:7357/assets/vendor.js:38627:33)
> at Class.willDestroy (http://localhost:7357/assets/plugins/discourse-shared-edits.js:258:24)
> at Class.superWrapper [as willDestroy] (http://localhost:7357/assets/vendor.js:41971:22)