### PR TITLE
FIX: Validate post when committing revision

### DIFF
--- a/app/models/shared_edit_revision.rb
+++ b/app/models/shared_edit_revision.rb
@@ -92,7 +92,6 @@ class SharedEditRevision < ActiveRecord::Base
     opts = {
       bypass_rate_limiter: true,
       bypass_bump: true,
-      skip_validations: true,
       skip_staff_log: true,
     }
 

--- a/spec/models/shared_edit_revision_spec.rb
+++ b/spec/models/shared_edit_revision_spec.rb
@@ -92,4 +92,21 @@ describe SharedEditRevision do
     expect(edit_rev.post_revision_id).to eq(rev.id)
 
   end
+
+  it "does not update the post if validation fails" do
+    user = Fabricate(:admin)
+    post = Fabricate(:post, user: user, raw: "Hello world")
+
+    SharedEditRevision.init!(post)
+    SharedEditRevision.revise!(
+      post_id: post.id,
+      user_id: user.id,
+      client_id: user.id,
+      revision: [{"d":11},"Test"],
+      version: 1,
+    )
+    SharedEditRevision.commit!(post.id)
+
+    expect(post.reload.raw).to eq("Hello world")
+  end
 end

--- a/spec/models/shared_edit_revision_spec.rb
+++ b/spec/models/shared_edit_revision_spec.rb
@@ -102,7 +102,7 @@ describe SharedEditRevision do
       post_id: post.id,
       user_id: user.id,
       client_id: user.id,
-      revision: [{"d":11},"Test"],
+      revision: [{ d: 11 }, "Test"],
       version: 1,
     )
     SharedEditRevision.commit!(post.id)


### PR DESCRIPTION
Committing shared edit revisions happened by editing posts using PostRevisor, but also by skipping validations.