### PR TITLE
FIX: adds support for addPostAdminMenuButton

### DIFF
--- a/assets/javascripts/initializers/shared-edits-init.js
+++ b/assets/javascripts/initializers/shared-edits-init.js
@@ -41,19 +41,17 @@ function initWithApi(api) {
         label: attrs.shared_edits_enabled
           ? "shared_edits.disable_shared_edits"
           : "shared_edits.enable_shared_edits",
-        action: (post, rerender) => {
+        action: async (post) => {
           let url = `/shared_edits/p/${post.id}/${
             post.shared_edits_enabled ? "disable" : "enable"
           }.json`;
 
-          ajax(url, { type: "PUT" })
-            .then(() => {
+          await ajax(url, { type: "PUT" })
+            .then((result) => {
               post.set(
                 "shared_edits_enabled",
                 post.shared_edits_enabled ? false : true
               );
-
-              rerender();
             })
             .catch(popupAjaxError);
         },

--- a/assets/javascripts/initializers/shared-edits-init.js
+++ b/assets/javascripts/initializers/shared-edits-init.js
@@ -47,7 +47,7 @@ function initWithApi(api) {
           }.json`;
 
           await ajax(url, { type: "PUT" })
-            .then((result) => {
+            .then(() => {
               post.set(
                 "shared_edits_enabled",
                 post.shared_edits_enabled ? false : true


### PR DESCRIPTION
In the near future it will be made to use `addPostAdminMenuButton` only with a plugin compatibility entry, but for the time being I need to be able to switch between the two states if the API is present or not.

This is related to the introduction of FloatKit.