### PR TITLE
FIX: TL4 users can use shared edit too

### DIFF
--- a/assets/javascripts/initializers/shared-edits-init.js
+++ b/assets/javascripts/initializers/shared-edits-init.js
@@ -31,7 +31,7 @@ function initWithApi(api) {
 
   if (api.addPostAdminMenuButton) {
     api.addPostAdminMenuButton((attrs) => {
-      if (!currentUser?.staff) {
+      if (!currentUser?.staff && currentUser?.trust_level < 4) {
         return;
       }
 


### PR DESCRIPTION
The existing code was checking on this through `!contents.children`, I prefer to use the more explicit form now.

No tests as the plugin as no js tests or system specs ATM,  it's out of the scope of the work Im doing on menus.