### PR TITLE
DEV: Update composer controller -> service

### DIFF
--- a/assets/javascripts/initializers/shared-edits-init.js
+++ b/assets/javascripts/initializers/shared-edits-init.js
@@ -234,7 +234,7 @@ function initWithApi(api) {
     },
   });
 
-  api.modifyClass("controller:composer", {
+  api.modifyClass("service:composer", {
     pluginId: PLUGIN_ID,
 
     open(opts) {


### PR DESCRIPTION
Core has a backwards-compat shim for this so this change is a no-op, but improves some things like `modifyClass` warning messages.