### PR TITLE
DEV: Move the composer service modification to pre-initializer

### DIFF
--- a/assets/javascripts/initializers/shared-edits-init.js
+++ b/assets/javascripts/initializers/shared-edits-init.js
@@ -3,15 +3,7 @@ import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { withPluginApi } from "discourse/lib/plugin-api";
 import { SAVE_ICONS, SAVE_LABELS } from "discourse/models/composer";
-import discourseComputed, {
-  observes,
-  on,
-} from "discourse-common/utils/decorators";
-import {
-  performSharedEdit,
-  setupSharedEdit,
-  teardownSharedEdit,
-} from "../lib/shared-edits";
+import discourseComputed, { on } from "discourse-common/utils/decorators";
 
 const SHARED_EDIT_ACTION = "sharedEdit";
 const PLUGIN_ID = "discourse-shared-edits";

--- a/assets/javascripts/initializers/shared-edits-init.js
+++ b/assets/javascripts/initializers/shared-edits-init.js
@@ -233,63 +233,6 @@ function initWithApi(api) {
       this._super(...arguments);
     },
   });
-
-  api.modifyClass("service:composer", {
-    pluginId: PLUGIN_ID,
-
-    open(opts) {
-      const openResponse = this._super(opts);
-      if (openResponse && openResponse.then) {
-        return openResponse.then(() => {
-          if (opts.action === SHARED_EDIT_ACTION) {
-            setupSharedEdit(this.model);
-          }
-        });
-      }
-    },
-
-    collapse() {
-      if (this.get("model.action") === SHARED_EDIT_ACTION) {
-        return this.close();
-      }
-      return this._super();
-    },
-
-    close() {
-      if (this.get("model.action") === SHARED_EDIT_ACTION) {
-        teardownSharedEdit(this.model);
-      }
-      return this._super();
-    },
-
-    save() {
-      if (this.get("model.action") === SHARED_EDIT_ACTION) {
-        return this.close();
-      }
-      return this._super.apply(this, arguments);
-    },
-
-    @on("init")
-    _listenForClose() {
-      this.appEvents.on("composer:close", () => {
-        this.close();
-      });
-    },
-
-    @observes("model.reply")
-    _handleSharedEdit() {
-      if (this.get("model.action") === SHARED_EDIT_ACTION) {
-        performSharedEdit(this.model);
-      }
-    },
-
-    _saveDraft() {
-      if (this.get("model.action") === SHARED_EDIT_ACTION) {
-        return;
-      }
-      return this._super();
-    },
-  });
 }
 
 export default {

--- a/assets/javascripts/pre-initializers/extend-composer-service.js
+++ b/assets/javascripts/pre-initializers/extend-composer-service.js
@@ -22,33 +22,30 @@ export default {
       api.modifyClass("service:composer", {
         pluginId: PLUGIN_ID,
 
-        open(opts) {
-          const openResponse = this._super(opts);
-          if (openResponse && openResponse.then) {
-            return openResponse.then(() => {
-              if (opts.action === SHARED_EDIT_ACTION) {
-                setupSharedEdit(this.model);
-              }
-            });
+        async open(opts) {
+          await this._super(opts);
+
+          if (opts.action === SHARED_EDIT_ACTION) {
+            setupSharedEdit(this.model);
           }
         },
 
         collapse() {
-          if (this.get("model.action") === SHARED_EDIT_ACTION) {
+          if (this.model.action === SHARED_EDIT_ACTION) {
             return this.close();
           }
           return this._super();
         },
 
         close() {
-          if (this.get("model.action") === SHARED_EDIT_ACTION) {
+          if (this.model.action === SHARED_EDIT_ACTION) {
             teardownSharedEdit(this.model);
           }
           return this._super();
         },
 
         save() {
-          if (this.get("model.action") === SHARED_EDIT_ACTION) {
+          if (this.model.action === SHARED_EDIT_ACTION) {
             return this.close();
           }
           return this._super.apply(this, arguments);
@@ -56,20 +53,18 @@ export default {
 
         @on("init")
         _listenForClose() {
-          this.appEvents.on("composer:close", () => {
-            this.close();
-          });
+          this.appEvents.on("composer:close", () => this.close());
         },
 
         @observes("model.reply")
         _handleSharedEdit() {
-          if (this.get("model.action") === SHARED_EDIT_ACTION) {
+          if (this.model.action === SHARED_EDIT_ACTION) {
             performSharedEdit(this.model);
           }
         },
 
         _saveDraft() {
-          if (this.get("model.action") === SHARED_EDIT_ACTION) {
+          if (this.model.action === SHARED_EDIT_ACTION) {
             return;
           }
           return this._super();

--- a/assets/javascripts/pre-initializers/extend-composer-service.js
+++ b/assets/javascripts/pre-initializers/extend-composer-service.js
@@ -1,0 +1,80 @@
+import { withPluginApi } from "discourse/lib/plugin-api";
+import { observes, on } from "discourse-common/utils/decorators";
+import {
+  performSharedEdit,
+  setupSharedEdit,
+  teardownSharedEdit,
+} from "../lib/shared-edits";
+
+const SHARED_EDIT_ACTION = "sharedEdit";
+const PLUGIN_ID = "discourse-shared-edits";
+
+export default {
+  name: "discourse-shared-edits-composer-service",
+
+  initialize: (container) => {
+    const siteSettings = container.lookup("service:site-settings");
+    if (!siteSettings.shared_edits_enabled) {
+      return;
+    }
+
+    withPluginApi("0.8.6", (api) => {
+      api.modifyClass("service:composer", {
+        pluginId: PLUGIN_ID,
+
+        open(opts) {
+          const openResponse = this._super(opts);
+          if (openResponse && openResponse.then) {
+            return openResponse.then(() => {
+              if (opts.action === SHARED_EDIT_ACTION) {
+                setupSharedEdit(this.model);
+              }
+            });
+          }
+        },
+
+        collapse() {
+          if (this.get("model.action") === SHARED_EDIT_ACTION) {
+            return this.close();
+          }
+          return this._super();
+        },
+
+        close() {
+          if (this.get("model.action") === SHARED_EDIT_ACTION) {
+            teardownSharedEdit(this.model);
+          }
+          return this._super();
+        },
+
+        save() {
+          if (this.get("model.action") === SHARED_EDIT_ACTION) {
+            return this.close();
+          }
+          return this._super.apply(this, arguments);
+        },
+
+        @on("init")
+        _listenForClose() {
+          this.appEvents.on("composer:close", () => {
+            this.close();
+          });
+        },
+
+        @observes("model.reply")
+        _handleSharedEdit() {
+          if (this.get("model.action") === SHARED_EDIT_ACTION) {
+            performSharedEdit(this.model);
+          }
+        },
+
+        _saveDraft() {
+          if (this.get("model.action") === SHARED_EDIT_ACTION) {
+            return;
+          }
+          return this._super();
+        },
+      });
+    });
+  },
+};


### PR DESCRIPTION
To avoid the issue:

```
[PLUGIN discourse-shared-edits] \"service:composer\" has already been initialized and registered as a singleton. Move the modifyClass call earlier in the boot process for changes to take effect.
```