### PR TITLE
DEV: Remove assertion on spec as side effect is introduced from a different plugin

### DIFF
--- a/spec/models/shared_edit_revision_spec.rb
+++ b/spec/models/shared_edit_revision_spec.rb
@@ -100,8 +100,6 @@ describe SharedEditRevision do
       version: 1,
     )
 
-    expect { SharedEditRevision.commit!(post.id) }.to raise_error(ActiveRecord::RecordInvalid)
-
     expect(post.reload.raw).to eq("Hello world")
   end
 end


### PR DESCRIPTION
In https://github.com/discourse/discourse-shared-edits/pull/84 (this plugin), the test assertion was added, but the cause of the assertion was from the poll plugin, not this plugin.

In https://github.com/discourse/discourse/pull/26573 (poll plugin), all posts are getting validated even if the post does not have a poll. This in turn raises a validation error for this plugin. https://github.com/discourse/discourse-shared-edits/pull/84 was committed due to this side effect, but the feature is not meant to be a deliberately raised error.