### PR TITLE
DEV: remove composer-editor monkey patch

### DIFF
--- a/assets/javascripts/discourse/initializers/shared-edits-init.js
+++ b/assets/javascripts/discourse/initializers/shared-edits-init.js
@@ -82,19 +82,6 @@ function initWithApi(api) {
   );
 
   api.modifyClass(
-    "component:composer-editor",
-    (Superclass) =>
-      class extends Superclass {
-        keyDown() {
-          super.keyDown?.(...arguments);
-          if (this.composer.action === SHARED_EDIT_ACTION) {
-            this.composer.set("lastKeyPress", Date.now());
-          }
-        }
-      }
-  );
-
-  api.modifyClass(
     "controller:topic",
     (Superclass) =>
       class extends Superclass {


### PR DESCRIPTION
https://github.com/discourse/discourse/pull/29629 changes `this.composer` within `composer-editor` to be the service instead of the model, as it is today.

We could just change `this.composer` to `this.composer.model` here, but unless I'm missing something, I don't think this code is doing anything – I couldn't find any other reference to `lastKeyPress`.