### PR TITLE
DEV: update from deprecated FA6 icon names pencil-alt and times

### DIFF
--- a/assets/javascripts/discourse/connectors/composer-fields-below/shared-edit-buttons.gjs
+++ b/assets/javascripts/discourse/connectors/composer-fields-below/shared-edit-buttons.gjs
@@ -18,7 +18,7 @@ export default class SharedEditButtons extends Component {
       <div class="leave-shared-edit">
         <DButton
           @action={{this.endSharedEdit}}
-          @icon={{if this.site.mobileView "times"}}
+          @icon={{if this.site.mobileView "xmark"}}
           @label={{if this.site.desktopView "shared_edits.done"}}
           title={{if this.site.mobileView (i18n "shared_edits.done")}}
           class={{if this.site.mobileView "btn-transparent" "btn-primary"}}

--- a/assets/javascripts/discourse/initializers/shared-edits-init.js
+++ b/assets/javascripts/discourse/initializers/shared-edits-init.js
@@ -16,7 +16,7 @@ function replaceButton(buttons, find, replace) {
 
 function initWithApi(api) {
   SAVE_LABELS[SHARED_EDIT_ACTION] = "composer.save_edit";
-  SAVE_ICONS[SHARED_EDIT_ACTION] = "pencil-alt";
+  SAVE_ICONS[SHARED_EDIT_ACTION] = "pencil";
 
   customizePostMenu(api);
 


### PR DESCRIPTION
This PR updates the deprecated pencil-alt and times icon names. For more detail, refer to the announcement at https://meta.discourse.org/t/-/325349.