### PR TITLE
FIX: move init to pre init so race conditions do not break extensibility

### DIFF
--- a/assets/javascripts/discourse/pre-initializers/extend-composer-service.js
+++ b/assets/javascripts/discourse/pre-initializers/extend-composer-service.js
@@ -5,6 +5,7 @@ const SHARED_EDIT_ACTION = "sharedEdit";
 
 export default {
   name: "discourse-shared-edits-composer-service",
+  before: "inject-discourse-objects",
 
   initialize: (container) => {
     const siteSettings = container.lookup("service:site-settings");


### PR DESCRIPTION
Competed with discourse-calendar and lost race
