### PR TITLE
FEATURE: allow shared edits to be enabled on any group

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@
 
 ## Scope & Feature Flags
 - Lives at `plugins/discourse-shared-edits`; everything here only runs when `SiteSetting.shared_edits_enabled` (defined in `config/settings.yml`) is true and the per-post custom field `shared_edits_enabled` has been toggled via `SharedEditRevision.toggle_shared_edits!`.
-- Guardian hook (`lib/discourse_shared_edits/guardian_extension.rb`) restricts enable/disable/reset/recover endpoints to staff or trust level 4+. Reuse `guardian.ensure_can_toggle_shared_edits!` for any new privileged action. Privileged endpoints must also call `guardian.ensure_can_see!(@post)` to prevent access to posts in restricted categories.
+- Guardian hook (`lib/discourse_shared_edits/guardian_extension.rb`) restricts enable/disable/reset/recover endpoints to users in `SiteSetting.shared_edits_toggle_allowed_groups` (defaults to staff and trust level 4). Reuse `guardian.ensure_can_toggle_shared_edits!` for any new privileged action. Privileged endpoints must also call `guardian.ensure_can_see!(@post)` to prevent access to posts in restricted categories.
 - API routes live under `/shared_edits` (`plugin.rb`). Do not rename them without updating the Ember service and the Pretender fixtures in `test/javascripts`.
 
 ## Backend Architecture & Expectations

--- a/app/controllers/discourse_shared_edits/revision_controller.rb
+++ b/app/controllers/discourse_shared_edits/revision_controller.rb
@@ -296,8 +296,13 @@ module ::DiscourseSharedEdits
     def recover
       guardian.ensure_can_see!(@post)
       guardian.ensure_can_toggle_shared_edits!
+      RateLimiter.new(
+        current_user,
+        "shared-edit-post-raw-recover-#{@post.id}",
+        10,
+        1.minute,
+      ).performed!
 
-      # Staff-only endpoint, skip rate limiting since it's already protected by guardian
       result =
         StateValidator.recover_from_post_raw(
           @post.id,
@@ -316,6 +321,7 @@ module ::DiscourseSharedEdits
     def reset
       guardian.ensure_can_see!(@post)
       guardian.ensure_can_toggle_shared_edits!
+      RateLimiter.new(current_user, "shared-edit-reset-#{@post.id}", 10, 1.minute).performed!
 
       new_version = SharedEditRevision.reset_history!(@post.id)
       if new_version.nil?

--- a/assets/javascripts/discourse/initializers/shared-edits-init.js
+++ b/assets/javascripts/discourse/initializers/shared-edits-init.js
@@ -62,7 +62,7 @@ function initWithApi(api, siteSettings) {
   const currentUser = api.getCurrentUser();
 
   api.addPostAdminMenuButton((attrs) => {
-    if (!currentUser?.staff && currentUser?.trust_level < 4) {
+    if (!currentUser?.can_toggle_shared_edits) {
       return;
     }
 

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -18,3 +18,4 @@ en:
     shared_edits_enabled: Enable shared, collaborative, editing on designated posts.
     shared_edits_editor_mode: "Editor mode for shared edits: markdown uses plain text, rich uses the ProseMirror rich text editor."
     shared_edits_commit_delay_seconds: "Seconds to wait before committing collaborative edits to the post. Lower values commit more frequently but may increase server load."
+    shared_edits_toggle_allowed_groups: "Groups allowed to enable or disable shared edits on posts."

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -20,3 +20,4 @@ plugins:
     allow_any: false
     disallowed_groups: "4" # @anonymous_users
     refresh: true
+    mandatory_values: "1" # @admins

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -13,3 +13,10 @@ plugins:
     default: 30
     min: 5
     max: 300
+  shared_edits_toggle_allowed_groups:
+    default: "1|2|14" # @admins, @moderators, @trust_level_4
+    type: group_list
+    list_type: compact
+    allow_any: false
+    disallowed_groups: "4" # @anonymous_users
+    refresh: true

--- a/lib/discourse_shared_edits/guardian_extension.rb
+++ b/lib/discourse_shared_edits/guardian_extension.rb
@@ -6,7 +6,7 @@ module DiscourseSharedEdits
 
     def can_toggle_shared_edits?
       SiteSetting.shared_edits_enabled && authenticated? &&
-        (is_staff? || @user.has_trust_level?(TrustLevel[4]))
+        @user.in_any_groups?(SiteSetting.shared_edits_toggle_allowed_groups_map)
     end
   end
 end

--- a/plugin.rb
+++ b/plugin.rb
@@ -50,6 +50,8 @@ after_initialize do
   register_post_custom_field_type("shared_edits_editor_usernames", :json)
   topic_view_post_custom_fields_allowlister { [DiscourseSharedEdits::SHARED_EDITS_ENABLED] }
 
+  add_to_serializer(:current_user, :can_toggle_shared_edits) { scope.can_toggle_shared_edits? }
+
   add_to_serializer(:post, :shared_edits_enabled) do
     if SiteSetting.shared_edits_enabled
       post_custom_fields[DiscourseSharedEdits::SHARED_EDITS_ENABLED]

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Discourse Shared Edits Plugin
 
 Discourse shared edits allows multiple users to collaboratively edit posts in real time.
-This feature is default disabled and must be enabled explicitly by moderators on posts.
+This feature is disabled by default and can be enabled explicitly on posts by users in the `shared_edits_toggle_allowed_groups` site setting, which defaults to staff and trust level 4.
 
 For more information, please see: https://meta.discourse.org/t/discourse-shared-edits/167583

--- a/spec/lib/guardian_spec.rb
+++ b/spec/lib/guardian_spec.rb
@@ -9,7 +9,10 @@ RSpec.describe Guardian do
 
   describe "#can_toggle_shared_edits?" do
     context "when shared edits are enabled" do
-      before { SiteSetting.shared_edits_enabled = true }
+      before do
+        SiteSetting.shared_edits_enabled = true
+        SiteSetting.shared_edits_toggle_allowed_groups = "1|2|14"
+      end
 
       it "allows the default groups" do
         aggregate_failures do
@@ -34,14 +37,18 @@ RSpec.describe Guardian do
 
         aggregate_failures do
           expect(Guardian.new(user)).to be_can_toggle_shared_edits
-          expect(Guardian.new(admin)).not_to be_can_toggle_shared_edits
+          expect(Guardian.new(admin)).to be_can_toggle_shared_edits
+          expect(Guardian.new(moderator)).not_to be_can_toggle_shared_edits
           expect(Guardian.new(tl4_user)).not_to be_can_toggle_shared_edits
         end
       end
     end
 
     context "when shared edits are disabled" do
-      before { SiteSetting.shared_edits_enabled = false }
+      before do
+        SiteSetting.shared_edits_enabled = false
+        SiteSetting.shared_edits_toggle_allowed_groups = "1|2|14"
+      end
 
       it "disallows users in configured groups" do
         aggregate_failures do

--- a/spec/lib/guardian_spec.rb
+++ b/spec/lib/guardian_spec.rb
@@ -4,52 +4,51 @@ RSpec.describe Guardian do
   fab!(:moderator)
   fab!(:admin)
   fab!(:user)
+  fab!(:tl4_user) { Fabricate(:user, trust_level: TrustLevel[4], refresh_auto_groups: true) }
+  fab!(:group)
 
   describe "#can_toggle_shared_edits?" do
-    context "when shared_edits_enabled is true" do
+    context "when shared edits are enabled" do
       before { SiteSetting.shared_edits_enabled = true }
 
-      it "disallows shared edits from anon" do
-        expect(Guardian.new.can_toggle_shared_edits?).to eq(false)
+      it "allows the default groups" do
+        aggregate_failures do
+          expect(Guardian.new(admin)).to be_can_toggle_shared_edits
+          expect(Guardian.new(moderator)).to be_can_toggle_shared_edits
+          expect(Guardian.new(tl4_user)).to be_can_toggle_shared_edits
+        end
       end
 
-      it "disallows shared edits for tl3 users" do
-        user.trust_level = 3
-        expect(Guardian.new(user).can_toggle_shared_edits?).to eq(false)
+      it "disallows users outside the configured groups" do
+        expect(Guardian.new(user)).not_to be_can_toggle_shared_edits
       end
 
-      it "disallows shared edits for regular users" do
-        expect(Guardian.new(user).can_toggle_shared_edits?).to eq(false)
+      it "disallows anonymous users" do
+        expect(Guardian.new).not_to be_can_toggle_shared_edits
       end
 
-      it "allows shared edits for moderators" do
-        expect(Guardian.new(moderator).can_toggle_shared_edits?).to eq(true)
-      end
+      it "uses the configured groups" do
+        SiteSetting.shared_edits_toggle_allowed_groups = group.id.to_s
+        group.add(user)
+        user.reload
 
-      it "allows shared edits for admins" do
-        expect(Guardian.new(admin).can_toggle_shared_edits?).to eq(true)
-      end
-
-      it "allows shared edits for tl4" do
-        user.trust_level = 4
-        expect(Guardian.new(user).can_toggle_shared_edits?).to eq(true)
+        aggregate_failures do
+          expect(Guardian.new(user)).to be_can_toggle_shared_edits
+          expect(Guardian.new(admin)).not_to be_can_toggle_shared_edits
+          expect(Guardian.new(tl4_user)).not_to be_can_toggle_shared_edits
+        end
       end
     end
 
-    context "when shared_edits_enabled is false" do
+    context "when shared edits are disabled" do
       before { SiteSetting.shared_edits_enabled = false }
 
-      it "disallows shared edits for admins" do
-        expect(Guardian.new(admin).can_toggle_shared_edits?).to eq(false)
-      end
-
-      it "disallows shared edits for moderators" do
-        expect(Guardian.new(moderator).can_toggle_shared_edits?).to eq(false)
-      end
-
-      it "disallows shared edits for tl4" do
-        user.trust_level = 4
-        expect(Guardian.new(user).can_toggle_shared_edits?).to eq(false)
+      it "disallows users in configured groups" do
+        aggregate_failures do
+          expect(Guardian.new(admin)).not_to be_can_toggle_shared_edits
+          expect(Guardian.new(moderator)).not_to be_can_toggle_shared_edits
+          expect(Guardian.new(tl4_user)).not_to be_can_toggle_shared_edits
+        end
       end
     end
   end

--- a/spec/requests/revision_controller_spec.rb
+++ b/spec/requests/revision_controller_spec.rb
@@ -2,10 +2,11 @@
 
 RSpec.describe DiscourseSharedEdits::RevisionController do
   fab!(:user)
-  fab!(:tl4_user) { Fabricate(:user, trust_level: TrustLevel[4]) }
+  fab!(:tl4_user) { Fabricate(:user, trust_level: TrustLevel[4], refresh_auto_groups: true) }
   fab!(:post1) { Fabricate(:post, user: user, raw: "Hello World, testing shared edits") }
   fab!(:admin)
   fab!(:group)
+  fab!(:toggle_group, :group)
   fab!(:private_category) { Fabricate(:private_category, group: group) }
   fab!(:private_post) { Fabricate(:post, topic: Fabricate(:topic, category: private_category)) }
 
@@ -34,6 +35,22 @@ RSpec.describe DiscourseSharedEdits::RevisionController do
       it "returns 403" do
         put "/shared_edits/p/#{post1.id}/enable"
         expect(response.status).to eq(403)
+      end
+    end
+
+    context "when user belongs to a configured toggle group" do
+      before do
+        SiteSetting.shared_edits_toggle_allowed_groups = toggle_group.id.to_s
+        toggle_group.add(user)
+        sign_in user
+      end
+
+      it "enables shared edits on a post" do
+        put "/shared_edits/p/#{post1.id}/enable"
+        expect(response.status).to eq(200)
+
+        post1.reload
+        expect(post1.custom_fields[DiscourseSharedEdits::SHARED_EDITS_ENABLED]).to eq(true)
       end
     end
 
@@ -122,6 +139,24 @@ RSpec.describe DiscourseSharedEdits::RevisionController do
       it "returns 403" do
         put "/shared_edits/p/#{post1.id}/disable"
         expect(response.status).to eq(403)
+      end
+    end
+
+    context "when user belongs to a configured toggle group" do
+      before do
+        SiteSetting.shared_edits_toggle_allowed_groups = toggle_group.id.to_s
+        toggle_group.add(user)
+        sign_in user
+      end
+
+      it "disables shared edits on a post" do
+        SharedEditRevision.toggle_shared_edits!(post1.id, true)
+
+        put "/shared_edits/p/#{post1.id}/disable"
+        expect(response.status).to eq(200)
+
+        post1.reload
+        expect(post1.custom_fields[DiscourseSharedEdits::SHARED_EDITS_ENABLED]).to be_nil
       end
     end
   end

--- a/spec/serializers/current_user_serializer_spec.rb
+++ b/spec/serializers/current_user_serializer_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+RSpec.describe CurrentUserSerializer do
+  fab!(:user)
+  fab!(:group)
+
+  before do
+    SiteSetting.shared_edits_enabled = true
+    SiteSetting.shared_edits_toggle_allowed_groups = group.id.to_s
+  end
+
+  describe "#can_toggle_shared_edits" do
+    it "serializes the current user's toggle permission" do
+      json = described_class.new(user, scope: Guardian.new(user), root: false).as_json
+      expect(json[:can_toggle_shared_edits]).to eq(false)
+
+      group.add(user)
+      reloaded_user = User.find(user.id)
+
+      json =
+        described_class.new(reloaded_user, scope: Guardian.new(reloaded_user), root: false).as_json
+      expect(json[:can_toggle_shared_edits]).to eq(true)
+    end
+  end
+end

--- a/test/javascripts/acceptance/composer-test.js
+++ b/test/javascripts/acceptance/composer-test.js
@@ -5,7 +5,7 @@ import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 acceptance(`Discourse Shared Edits | Composer`, function (needs) {
   let commitCalls;
 
-  needs.user();
+  needs.user({ can_toggle_shared_edits: true });
   needs.settings({
     rich_editor: true,
   });

--- a/test/javascripts/acceptance/shared-edits-cursor-test.js
+++ b/test/javascripts/acceptance/shared-edits-cursor-test.js
@@ -33,7 +33,7 @@ function base64urlToUint8Array(str) {
 acceptance(`Discourse Shared Edits | Cursors & Selection`, function (needs) {
   let updateRequestBodies;
 
-  needs.user();
+  needs.user({ can_toggle_shared_edits: true });
   needs.pretender((server, helper) => {
     updateRequestBodies = [];
 

--- a/test/javascripts/acceptance/shared-edits-lifecycle-test.js
+++ b/test/javascripts/acceptance/shared-edits-lifecycle-test.js
@@ -13,7 +13,7 @@ acceptance("Discourse Shared Edits | Lifecycle", function (needs) {
   let putRequests;
   let commitCalls;
 
-  needs.user();
+  needs.user({ can_toggle_shared_edits: true });
   needs.settings({ shared_edits_enabled: true });
 
   needs.pretender((server, helper) => {
@@ -226,7 +226,7 @@ acceptance("Discourse Shared Edits | Lifecycle", function (needs) {
 });
 
 acceptance("Discourse Shared Edits | Lifecycle with State", function (needs) {
-  needs.user();
+  needs.user({ can_toggle_shared_edits: true });
   needs.settings({ shared_edits_enabled: true });
 
   needs.pretender((server, helper) => {

--- a/test/javascripts/acceptance/shared-edits-sync-test.js
+++ b/test/javascripts/acceptance/shared-edits-sync-test.js
@@ -18,7 +18,7 @@ const TEXTAREA_SELECTOR = "#reply-control textarea.d-editor-input";
 acceptance("Discourse Shared Edits | Text Synchronization", function (needs) {
   let putRequests;
 
-  needs.user();
+  needs.user({ can_toggle_shared_edits: true });
   needs.settings({ shared_edits_enabled: true });
 
   needs.pretender((server, helper) => {

--- a/test/javascripts/acceptance/shared-edits-toggle-permission-test.js
+++ b/test/javascripts/acceptance/shared-edits-toggle-permission-test.js
@@ -1,0 +1,18 @@
+import { click, visit } from "@ember/test-helpers";
+import { test } from "qunit";
+import { acceptance } from "discourse/tests/helpers/qunit-helpers";
+
+acceptance("Discourse Shared Edits | Toggle permissions", function (needs) {
+  needs.user({ can_toggle_shared_edits: false });
+  needs.settings({ shared_edits_enabled: true });
+
+  test("hides the post admin toggle action", async function (assert) {
+    await visit("/t/internationalization-localization/280");
+    await click(".show-more-actions");
+    await click(".show-post-admin-menu");
+
+    assert
+      .dom(".admin-toggle-shared-edits")
+      .doesNotExist("the shared edits toggle action is hidden");
+  });
+});


### PR DESCRIPTION
Allow sites to choose which groups can enable or disable shared edits instead of hardcoding staff and TL4 users. Expose the permission on the current user serializer so the admin menu can hide toggle actions for unauthorized users.

Add rate limits to privileged reset and recover endpoints, and update specs, acceptance tests, docs, and settings copy for the new permission model.
