### PR TITLE
FIX: Prevent diffing against stale snapshot or position

### DIFF
--- a/assets/javascripts/discourse/lib/shared-edits/encoding-utils.js
+++ b/assets/javascripts/discourse/lib/shared-edits/encoding-utils.js
@@ -63,8 +63,9 @@ export function decodeRelativePositionFromBase64url(base64url) {
 }
 
 // Text diff algorithm - applies minimal changes to Y.Text
+export function applyDiff(yText, after) {
+  const before = yText.toString();
 
-export function applyDiff(yText, before, after) {
   if (before === after) {
     return;
   }

--- a/assets/javascripts/discourse/lib/shared-edits/markdown-sync.js
+++ b/assets/javascripts/discourse/lib/shared-edits/markdown-sync.js
@@ -320,41 +320,7 @@ export default class MarkdownSync {
         return;
       }
 
-      let appliedSurgically = false;
-
-      if (event.delta) {
-        let expectedOldLength = textValue.length;
-        let insertLen = 0;
-        let deleteLen = 0;
-
-        for (const op of event.delta) {
-          if (op.insert) {
-            insertLen += typeof op.insert === "string" ? op.insert.length : 0;
-          } else if (op.delete) {
-            deleteLen += op.delete;
-          }
-        }
-        expectedOldLength = expectedOldLength - insertLen + deleteLen;
-
-        if (currentValue.length === expectedOldLength) {
-          let index = 0;
-          event.delta.forEach((op) => {
-            if (op.retain) {
-              index += op.retain;
-            } else if (op.insert) {
-              textarea.setRangeText(op.insert, index, index);
-              index += op.insert.length;
-            } else if (op.delete) {
-              textarea.setRangeText("", index, index + op.delete);
-            }
-          });
-          appliedSurgically = true;
-        }
-      }
-
-      if (!appliedSurgically) {
-        this.#applyDiffToTextarea(textarea, currentValue, textValue);
-      }
+      this.#applyDiffToTextarea(textarea, currentValue, textValue);
 
       this.cursorOverlay?.refresh();
 

--- a/assets/javascripts/discourse/lib/shared-edits/markdown-sync.js
+++ b/assets/javascripts/discourse/lib/shared-edits/markdown-sync.js
@@ -305,38 +305,41 @@ export default class MarkdownSync {
       this.#pendingRelativeSelection = null;
     }
 
-    if (!adjustedSelection) {
-      adjustedSelection = transformSelection(selection, event.delta || []);
+    const textValue = text.toString();
+    const currentValue = textarea?.value;
+
+    if (!adjustedSelection && selection && currentValue !== undefined) {
+      adjustedSelection = this.#transformSelectionThroughDiff(
+        currentValue,
+        textValue,
+        selection
+      );
     }
 
-    const textValue = text.toString();
     suppressComposerChangeFn?.(() => {
       this.composer.model?.set("reply", textValue);
     });
 
-    if (textarea) {
-      const currentValue = textarea.value;
-      if (currentValue === textValue) {
-        return;
-      }
+    if (!textarea || currentValue === textValue) {
+      return;
+    }
 
-      this.#applyDiffToTextarea(textarea, currentValue, textValue);
+    this.#applyDiffToTextarea(textarea, currentValue, textValue);
 
-      this.cursorOverlay?.refresh();
+    this.cursorOverlay?.refresh();
 
-      if (adjustedSelection) {
-        textarea.setSelectionRange(
-          adjustedSelection.start,
-          adjustedSelection.end,
-          adjustedSelection.direction || "none"
-        );
-      }
+    if (adjustedSelection) {
+      textarea.setSelectionRange(
+        adjustedSelection.start,
+        adjustedSelection.end,
+        adjustedSelection.direction || "none"
+      );
+    }
 
-      if (scrollTop !== undefined && textarea.scrollTop !== scrollTop) {
-        window.requestAnimationFrame(() => {
-          textarea.scrollTop = scrollTop;
-        });
-      }
+    if (scrollTop !== undefined && textarea.scrollTop !== scrollTop) {
+      window.requestAnimationFrame(() => {
+        textarea.scrollTop = scrollTop;
+      });
     }
   }
 

--- a/assets/javascripts/discourse/lib/shared-edits/rich-mode-sync.js
+++ b/assets/javascripts/discourse/lib/shared-edits/rich-mode-sync.js
@@ -166,7 +166,7 @@ export default class RichModeSync {
     }
 
     doc.transact(() => {
-      applyDiff(text, currentText, newText);
+      applyDiff(text, newText);
     }, "xmlSync");
 
     return true;

--- a/assets/javascripts/discourse/services/shared-edit-manager.js
+++ b/assets/javascripts/discourse/services/shared-edit-manager.js
@@ -378,7 +378,7 @@ export default class SharedEditManager extends Service {
           localText !== pendingText
         ) {
           this.#yjsDocument?.doc?.transact(
-            () => applyDiff(this.#yjsDocument.text, pendingText, localText),
+            () => applyDiff(this.#yjsDocument.text, localText),
             this
           );
           pendingText = localText;
@@ -701,7 +701,7 @@ export default class SharedEditManager extends Service {
     }
 
     this.#yjsDocument.doc.transact(
-      () => applyDiff(this.#yjsDocument.text, current, next),
+      () => applyDiff(this.#yjsDocument.text, next),
       this
     );
   }

--- a/support/debug_recovery.js
+++ b/support/debug_recovery.js
@@ -37,7 +37,11 @@ async function run() {
     await page.waitForTimeout(500);
     // Debug: see what buttons are available
     const buttons = await page.$$eval("#post_2 button", (btns) =>
-      btns.map((b) => ({ class: b.className, title: b.title, text: b.innerText }))
+      btns.map((b) => ({
+        class: b.className,
+        title: b.title,
+        text: b.innerText,
+      }))
     );
     console.log("Available buttons on post_2:", JSON.stringify(buttons));
 
@@ -203,7 +207,13 @@ async function run() {
 
     console.log("\n=== RELEVANT CONSOLE LOGS ===");
     consoleLogs
-      .filter((log) => log.includes("[SharedEdits]") || log.includes("[error]") || log.includes("composer") || log.includes("Composer"))
+      .filter(
+        (log) =>
+          log.includes("[SharedEdits]") ||
+          log.includes("[error]") ||
+          log.includes("composer") ||
+          log.includes("Composer")
+      )
       .forEach((log) => console.log(log));
   } catch (e) {
     console.error("Error:", e);

--- a/test/javascripts/unit/lib/encoding-utils-test.js
+++ b/test/javascripts/unit/lib/encoding-utils-test.js
@@ -1,0 +1,68 @@
+import { setupTest } from "ember-qunit";
+import { module, test } from "qunit";
+import { applyDiff } from "discourse/plugins/discourse-shared-edits/discourse/lib/shared-edits/encoding-utils";
+
+class FakeYText {
+  constructor(value) {
+    this._value = value;
+  }
+
+  toString() {
+    return this._value;
+  }
+
+  delete(start, len) {
+    this._value = this._value.slice(0, start) + this._value.slice(start + len);
+  }
+
+  insert(start, str) {
+    this._value = this._value.slice(0, start) + str + this._value.slice(start);
+  }
+}
+
+module("Discourse Shared Edits | Unit | encoding-utils", function (hooks) {
+  setupTest(hooks);
+
+  test("does nothing when the text is already the target value", function (assert) {
+    const yText = new FakeYText("unchanged");
+
+    applyDiff(yText, "unchanged");
+
+    assert.strictEqual(yText.toString(), "unchanged");
+  });
+
+  test("handles insert at the beginning of text", function (assert) {
+    const yText = new FakeYText("initial content");
+
+    applyDiff(yText, "PREFIX initial content");
+
+    assert.strictEqual(yText.toString(), "PREFIX initial content");
+  });
+
+  test("handles delete in the middle of text", function (assert) {
+    const yText = new FakeYText("initial content");
+
+    applyDiff(yText, "initient");
+
+    assert.strictEqual(yText.toString(), "initient");
+  });
+
+  test("handles replacement (delete + insert) in the middle of text", function (assert) {
+    const yText = new FakeYText("initial content");
+
+    applyDiff(yText, "initial text");
+
+    assert.strictEqual(yText.toString(), "initial text");
+  });
+
+  test("uses the current state of yText", function (assert) {
+    const yText = new FakeYText("hello world");
+    yText.insert(5, ", beautiful");
+
+    assert.strictEqual(yText.toString(), "hello, beautiful world");
+
+    applyDiff(yText, "hello world!");
+
+    assert.strictEqual(yText.toString(), "hello world!");
+  });
+});

--- a/test/javascripts/unit/lib/markdown-sync-test.js
+++ b/test/javascripts/unit/lib/markdown-sync-test.js
@@ -124,6 +124,24 @@ module("Unit | Lib | shared-edits | markdown-sync", function (hooks) {
       cb()
     );
 
-    assert.strictEqual(textarea.value, "abcd");
+    assert.strictEqual(textarea.value, "abcd", "the DOM value is patched");
+  });
+
+  test("preserves the caret against the actual diff when the DOM is stale (regression)", function (assert) {
+    textarea.value = "hello world";
+    textarea.setSelectionRange(0, 0);
+
+    const event = { delta: [{ delete: 5 }, { insert: "hi mars" }] };
+    const currentYText = { toString: () => "hi mars" };
+
+    sync.handleTextChange(event, { origin: {} }, currentYText, {}, (cb) =>
+      cb()
+    );
+
+    assert.strictEqual(
+      textarea.selectionStart,
+      0,
+      "the caret stays before the untouched shared prefix instead of jumping to where the delta claims"
+    );
   });
 });

--- a/test/javascripts/unit/lib/markdown-sync-test.js
+++ b/test/javascripts/unit/lib/markdown-sync-test.js
@@ -3,7 +3,7 @@ import { module, test } from "qunit";
 import MarkdownSync from "discourse/plugins/discourse-shared-edits/discourse/lib/shared-edits/markdown-sync";
 import { ensureYjsLoaded } from "discourse/plugins/discourse-shared-edits/discourse/lib/shared-edits/yjs-document";
 
-module("Unit | Lib | shared-edits | markdown-sync", function (hooks) {
+module("Unit | Lib | shared-edits | markdown-sync", function(hooks) {
   setupTest(hooks);
 
   let container;
@@ -12,7 +12,7 @@ module("Unit | Lib | shared-edits | markdown-sync", function (hooks) {
   let doc;
   let text;
 
-  hooks.beforeEach(async function () {
+  hooks.beforeEach(async function() {
     const Y = await ensureYjsLoaded();
     container = document.createElement("div");
     container.id = "reply-control";
@@ -25,20 +25,20 @@ module("Unit | Lib | shared-edits | markdown-sync", function (hooks) {
     doc = new Y.Doc();
     text = doc.getText("post");
     text.insert(0, textarea.value);
-    sync = new MarkdownSync(this.owner);
+    sync = new MarkdownSync(this);
     text.observe((event, transaction) => {
       sync.handleTextChange(event, transaction, text, doc);
     });
     sync.attach(doc, text, null);
   });
 
-  hooks.afterEach(function () {
+  hooks.afterEach(function() {
     sync.detach();
     doc.destroy();
     container.remove();
   });
 
-  test("uses the current caret after local selection movement", function (assert) {
+  test("uses the current caret after local selection movement", function(assert) {
     textarea.setSelectionRange(10, 10);
     sync.setPendingRelativeSelection(sync.captureRelativeSelection(text));
 
@@ -53,7 +53,7 @@ module("Unit | Lib | shared-edits | markdown-sync", function (hooks) {
     );
   });
 
-  test("preserves a backward selection through a remote edit", function (assert) {
+  test("preserves a backward selection through a remote edit", function(assert) {
     textarea.setSelectionRange(2, 5, "backward");
 
     doc.transact(() => text.insert(0, "X"), { type: "remote" });
@@ -69,7 +69,7 @@ module("Unit | Lib | shared-edits | markdown-sync", function (hooks) {
     );
   });
 
-  test("transforms a dragged selection through disjoint remote updates", async function (assert) {
+  test("transforms a dragged selection through disjoint remote updates", async function(assert) {
     sync.onSelectionEnd = () => sync.syncTextareaAfterSelection(text);
     textarea.setSelectionRange(5, 7);
     textarea.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
@@ -86,7 +86,7 @@ module("Unit | Lib | shared-edits | markdown-sync", function (hooks) {
     );
   });
 
-  test("restores the caret against the pre-undo document", function (assert) {
+  test("restores the caret against the pre-undo document", function(assert) {
     const Y = window.Y;
     const undoManager = new Y.UndoManager(text, {
       trackedOrigins: new Set([this.owner]),
@@ -112,5 +112,18 @@ module("Unit | Lib | shared-edits | markdown-sync", function (hooks) {
       "the caret returns to the edit position"
     );
     undoManager.destroy();
+  });
+
+  test("patches the DOM value against the Yjs target instead of only relying on the event delta (regression)", function (assert) {
+    textarea.value = "xyz";
+
+    const event = { delta: [{ retain: 3 }, { insert: "d" }] };
+    const currentYText = { toString: () => "abcd" };
+
+    sync.handleTextChange(event, { origin: {} }, currentYText, {}, (cb) =>
+      cb()
+    );
+
+    assert.strictEqual(textarea.value, "abcd");
   });
 });

--- a/test/javascripts/unit/lib/markdown-sync-test.js
+++ b/test/javascripts/unit/lib/markdown-sync-test.js
@@ -3,7 +3,7 @@ import { module, test } from "qunit";
 import MarkdownSync from "discourse/plugins/discourse-shared-edits/discourse/lib/shared-edits/markdown-sync";
 import { ensureYjsLoaded } from "discourse/plugins/discourse-shared-edits/discourse/lib/shared-edits/yjs-document";
 
-module("Unit | Lib | shared-edits | markdown-sync", function(hooks) {
+module("Unit | Lib | shared-edits | markdown-sync", function (hooks) {
   setupTest(hooks);
 
   let container;
@@ -12,7 +12,7 @@ module("Unit | Lib | shared-edits | markdown-sync", function(hooks) {
   let doc;
   let text;
 
-  hooks.beforeEach(async function() {
+  hooks.beforeEach(async function () {
     const Y = await ensureYjsLoaded();
     container = document.createElement("div");
     container.id = "reply-control";
@@ -32,13 +32,13 @@ module("Unit | Lib | shared-edits | markdown-sync", function(hooks) {
     sync.attach(doc, text, null);
   });
 
-  hooks.afterEach(function() {
+  hooks.afterEach(function () {
     sync.detach();
     doc.destroy();
     container.remove();
   });
 
-  test("uses the current caret after local selection movement", function(assert) {
+  test("uses the current caret after local selection movement", function (assert) {
     textarea.setSelectionRange(10, 10);
     sync.setPendingRelativeSelection(sync.captureRelativeSelection(text));
 
@@ -53,7 +53,7 @@ module("Unit | Lib | shared-edits | markdown-sync", function(hooks) {
     );
   });
 
-  test("preserves a backward selection through a remote edit", function(assert) {
+  test("preserves a backward selection through a remote edit", function (assert) {
     textarea.setSelectionRange(2, 5, "backward");
 
     doc.transact(() => text.insert(0, "X"), { type: "remote" });
@@ -69,7 +69,7 @@ module("Unit | Lib | shared-edits | markdown-sync", function(hooks) {
     );
   });
 
-  test("transforms a dragged selection through disjoint remote updates", async function(assert) {
+  test("transforms a dragged selection through disjoint remote updates", async function (assert) {
     sync.onSelectionEnd = () => sync.syncTextareaAfterSelection(text);
     textarea.setSelectionRange(5, 7);
     textarea.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
@@ -86,7 +86,7 @@ module("Unit | Lib | shared-edits | markdown-sync", function(hooks) {
     );
   });
 
-  test("restores the caret against the pre-undo document", function(assert) {
+  test("restores the caret against the pre-undo document", function (assert) {
     const Y = window.Y;
     const undoManager = new Y.UndoManager(text, {
       trackedOrigins: new Set([this.owner]),


### PR DESCRIPTION
This change aims to prevent diffing against a stale snapshot/position when applying a change in the scenario of multiple concurrent edits on the same post.

See the corresponding topic in meta: https://meta.discourse.org/t/prevent-race-condition-during-concurrent-edits/407261

**Changes**

1. Update `applyDiff` to use current state of `yText`

    Change the `applyDiff` utility to read out the current state of `yText` as its "before" content, rather then basing computations on a passed in "before" snapshot of the content. With concurrent edits happening, the snapshot can be outdated already and not reflect the current editor state any more, as its computed synchronously before.

    This stabilizes the editing experience for multiple users concurrently editing the same post. Before, the passed on "before" snapshot may already be outdated as concurrent edits where made in the editor. So it's content did not reflect the contents of yText anymore. Applying the diff would then result in weird splitting of words, inserts in the wrong place and loss of characters.

    With this change applied, concurrent edits result in a more human readable result, even when changes are happening concurrently in the same place.

2. Update `handleTextChange` for markdown

    Remove some optimization code from the markdown sync that was causing problems for concurrent edits: diffs where applied in the wrong place, etc.

    With this change, we always compute a real diff between the textarea's current value and the target. The approach before was looking at the event delta and the length of the text, rather than the actual content.
