### PR TITLE
Revert "DEV: Use model extension APIs instead of modifyClass (#166)"

### DIFF
--- a/.github/workflows/discourse-plugin.yml
+++ b/.github/workflows/discourse-plugin.yml
@@ -9,5 +9,3 @@ on:
 jobs:
   ci:
     uses: discourse/.github/.github/workflows/discourse-plugin.yml@v1
-    with:
-      core_ref: model-extension-api

--- a/assets/javascripts/discourse/initializers/shared-edits-init.js
+++ b/assets/javascripts/discourse/initializers/shared-edits-init.js
@@ -95,13 +95,18 @@ function initWithApi(api, siteSettings) {
     }
   });
 
-  api.addModelGetter("composer", "creatingSharedEdit", function () {
-    return this.get("action") === SHARED_EDIT_ACTION;
-  });
+  api.modifyClass(
+    "model:composer",
+    (Superclass) =>
+      class extends Superclass {
+        get creatingSharedEdit() {
+          return this.get("action") === SHARED_EDIT_ACTION;
+        }
 
-  api.registerValueTransformer(
-    "composer-editing-post",
-    ({ value, context }) => value || context.composer.creatingSharedEdit
+        get editingPost() {
+          return super.editingPost || this.creatingSharedEdit;
+        }
+      }
   );
 
   api.modifyClass(


### PR DESCRIPTION
This reverts commit b26384ff11be1156d5f02d90ac0ca7bc3b6ffd46.
